### PR TITLE
fix: show initial fade effect

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,20 +1,20 @@
 let element = $('.title h2:last');
+// Hide the element initially so the first fade-in animation is visible
+element.hide();
 
-    let texts = ['Healing Holistic Way','Yoga','Mind','Body','Soul','Diet','Homeopathy']
-    let currentindex=0;
+let texts = ['Healing Holistic Way','Yoga','Mind','Body','Soul','Diet','Homeopathy'];
+let currentindex = 0;
 
-    function typeText() {
-        element.text(texts[currentindex]);
-        element.fadeIn(2000);
-        setTimeout(eraseText,2000);
-        
-    }
+function typeText() {
+    element.text(texts[currentindex]);
+    element.fadeIn(2000);
+    setTimeout(eraseText, 2000);
+}
 
-    function eraseText() {
-        element.fadeOut(2000)
-        currentindex = (currentindex+1) % texts.length;
-        setTimeout(typeText,2000);
-    }
+function eraseText() {
+    element.fadeOut(2000);
+    currentindex = (currentindex + 1) % texts.length;
+    setTimeout(typeText, 2000);
+}
 
-typeText()
-
+typeText();


### PR DESCRIPTION
## Summary
- ensure rotating title text is hidden before animation for visible first fade

## Testing
- `node --check main.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a489473b98832994d1a1758624527f